### PR TITLE
Add Galveston Group demo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@ Galveston Group is a political finance platform demo featuring a Python FastAPI 
 
 ## Development
 
-### Backend
+### Run the App
 ```
 cd backend
 pip install -r requirements.txt
 uvicorn main:app --reload
 ```
-
-### Frontend
-Open `frontend/index.html` in a browser. The page uses CDN builds of React and Tailwind, so no build step is required.
+Then open [http://localhost:8000](http://localhost:8000) in a browser to use the demo. The FastAPI server also serves the React frontend from the `frontend` directory.
 
 ## Testing
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Galveston Group Demo
+
+Galveston Group is a political finance platform demo featuring a Python FastAPI backend and a React frontend. The demo supports two roles: PAC organisations and individual donors. Each role receives a tailored dashboard for tracking funds, donations and portfolios.
+
+## Development
+
+### Backend
+```
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+### Frontend
+Open `frontend/index.html` in a browser. The page uses CDN builds of React and Tailwind, so no build step is required.
+
+## Testing
+```
+cd backend
+pytest
+```
+```
+cd frontend
+npm test
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,8 @@
-from fastapi import FastAPI, HTTPException, Request
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 app = FastAPI(title="Galveston Group API")
@@ -7,10 +10,14 @@ app = FastAPI(title="Galveston Group API")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Serve static frontend files
+frontend_path = Path(__file__).resolve().parent.parent / "frontend"
+app.mount("/", StaticFiles(directory=frontend_path, html=True), name="frontend")
 
 class LoginRequest(BaseModel):
     email: str
@@ -44,17 +51,17 @@ DONOR_DASHBOARD = {
     ],
 }
 
-@app.post("/login")
+@app.post("/api/login")
 async def login(data: LoginRequest):
     user = USERS.get(data.email)
     if not user or user["password"] != data.password:
         raise HTTPException(status_code=401, detail="Invalid credentials")
     return {"token": "fake-token", "user": {"email": data.email, "role": user["role"], "name": user["name"]}}
 
-@app.get("/pac/dashboard")
+@app.get("/api/pac/dashboard")
 async def pac_dashboard():
     return PAC_DASHBOARD
 
-@app.get("/donor/dashboard")
+@app.get("/api/donor/dashboard")
 async def donor_dashboard():
     return DONOR_DASHBOARD

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,60 @@
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+app = FastAPI(title="Galveston Group API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+USERS = {
+    "pac@example.com": {"password": "test", "role": "pac", "name": "Green Future PAC"},
+    "donor@example.com": {"password": "test", "role": "donor", "name": "Jane Donor"},
+}
+
+PAC_DASHBOARD = {
+    "funds": 250000,
+    "transactions": [
+        {"type": "donation", "amount": 5000, "source": "John Doe"},
+        {"type": "disbursement", "amount": 2000, "target": "Campaign X"},
+    ],
+    "portfolio": [
+        {"candidate": "Alice Smith", "amount": 10000},
+        {"candidate": "Bob Johnson", "amount": 15000},
+    ],
+}
+
+DONOR_DASHBOARD = {
+    "top_pacs": [
+        {"name": "Green Future PAC", "policy_tags": ["climate", "energy"]},
+        {"name": "Liberty Now PAC", "policy_tags": ["defense", "economy"]},
+    ],
+    "portfolio": [
+        {"pac": "Green Future PAC", "amount": 200},
+        {"pac": "Liberty Now PAC", "amount": 150},
+    ],
+}
+
+@app.post("/login")
+async def login(data: LoginRequest):
+    user = USERS.get(data.email)
+    if not user or user["password"] != data.password:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    return {"token": "fake-token", "user": {"email": data.email, "role": user["role"], "name": user["name"]}}
+
+@app.get("/pac/dashboard")
+async def pac_dashboard():
+    return PAC_DASHBOARD
+
+@app.get("/donor/dashboard")
+async def donor_dashboard():
+    return DONOR_DASHBOARD

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/backend/test_backend.py
+++ b/backend/test_backend.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_login_pac():
+    resp = client.post("/login", json={"email": "pac@example.com", "password": "test"})
+    assert resp.status_code == 200
+    assert resp.json()["user"]["role"] == "pac"
+
+def test_pac_dashboard():
+    resp = client.get("/pac/dashboard")
+    data = resp.json()
+    assert "funds" in data
+    assert isinstance(data["transactions"], list)

--- a/backend/test_backend.py
+++ b/backend/test_backend.py
@@ -4,12 +4,12 @@ from main import app
 client = TestClient(app)
 
 def test_login_pac():
-    resp = client.post("/login", json={"email": "pac@example.com", "password": "test"})
+    resp = client.post("/api/login", json={"email": "pac@example.com", "password": "test"})
     assert resp.status_code == 200
     assert resp.json()["user"]["role"] == "pac"
 
 def test_pac_dashboard():
-    resp = client.get("/pac/dashboard")
+    resp = client.get("/api/pac/dashboard")
     data = resp.json()
     assert "funds" in data
     assert isinstance(data["transactions"], list)

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -9,7 +9,7 @@ function Login({ onLogin }) {
     e.preventDefault();
     setError(null);
     try {
-      const resp = await fetch('http://localhost:8000/login', {
+      const resp = await fetch('/api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })
@@ -38,7 +38,7 @@ function Login({ onLogin }) {
 function PacDashboard() {
   const [data, setData] = useState(null);
   useEffect(() => {
-    fetch('http://localhost:8000/pac/dashboard').then(r => r.json()).then(setData);
+    fetch('/api/pac/dashboard').then(r => r.json()).then(setData);
   }, []);
   useEffect(() => {
     if (data) {
@@ -64,7 +64,7 @@ function PacDashboard() {
 function DonorDashboard() {
   const [data, setData] = useState(null);
   useEffect(() => {
-    fetch('http://localhost:8000/donor/dashboard').then(r => r.json()).then(setData);
+    fetch('/api/donor/dashboard').then(r => r.json()).then(setData);
   }, []);
   if (!data) return <div className="p-4">Loading...</div>;
   return (

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -1,0 +1,86 @@
+const { useState, useEffect } = React;
+
+function Login({ onLogin }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const resp = await fetch('http://localhost:8000/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (!resp.ok) throw new Error('Login failed');
+      const data = await resp.json();
+      onLogin(data.user);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <form onSubmit={submit} className="bg-white p-6 rounded shadow-md w-80">
+        <h1 className="text-xl mb-4 text-center">Galveston Group</h1>
+        {error && <div className="text-red-500 mb-2">{error}</div>}
+        <input className="border p-2 w-full mb-3" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input type="password" className="border p-2 w-full mb-3" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <button className="bg-blue-600 text-white w-full py-2">Login</button>
+      </form>
+    </div>
+  );
+}
+
+function PacDashboard() {
+  const [data, setData] = useState(null);
+  useEffect(() => {
+    fetch('http://localhost:8000/pac/dashboard').then(r => r.json()).then(setData);
+  }, []);
+  useEffect(() => {
+    if (data) {
+      const ctx = document.getElementById('pacChart').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: data.transactions.map(t => t.type),
+          datasets: [{ label: 'Amount', data: data.transactions.map(t => t.amount), backgroundColor: 'rgba(59,130,246,0.5)' }]
+        }
+      });
+    }
+  }, [data]);
+  if (!data) return <div className="p-4">Loading...</div>;
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl mb-4">Funds: ${'{'}data.funds{'}'}</h2>
+      <canvas id="pacChart" height="100"></canvas>
+    </div>
+  );
+}
+
+function DonorDashboard() {
+  const [data, setData] = useState(null);
+  useEffect(() => {
+    fetch('http://localhost:8000/donor/dashboard').then(r => r.json()).then(setData);
+  }, []);
+  if (!data) return <div className="p-4">Loading...</div>;
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl mb-4">Top PACs</h2>
+      <ul className="list-disc pl-5">
+        {data.top_pacs.map(p => <li key={p.name}>{p.name} - {p.policy_tags.join(', ')}</li>)}
+      </ul>
+    </div>
+  );
+}
+
+function App() {
+  const [user, setUser] = useState(null);
+  if (!user) return <Login onLogin={setUser} />;
+  return user.role === 'pac' ? <PacDashboard /> : <DonorDashboard />;
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Galveston Group</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="root"></div>
+  <script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "galveston-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "echo 'No tests specified'"
+  }
+}

--- a/main
+++ b/main
@@ -1,7 +1,0 @@
-echo "# Galveston" >> README.md
-git init
-git add README.md
-git commit -m "first commit"
-git branch -M main
-git remote add origin https://github.com/rhyscooper99/Galveston.git
-git push -u origin main

--- a/open app
+++ b/open app
@@ -1,0 +1,3 @@
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with mock login and dashboard endpoints for PACs and donors
- build React + Tailwind frontend consuming the API and displaying simple dashboards
- add basic docs and placeholders for testing

## Testing
- `pytest` *(fails: No module named 'fastapi')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894bc64727483279170a319cdf6c7d6